### PR TITLE
[TASK] Create WizardItemsHookSubscriber

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -1,0 +1,28 @@
+<?php
+namespace FluidTYPO3\FluidcontentCore\Hooks;
+
+/*
+ * This file is part of the FluidTYPO3/FluidcontentCore project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Backend\Controller\ContentElement\NewContentElementController;
+use TYPO3\CMS\Backend\Wizard\NewContentElementWizardHookInterface;
+
+/**
+ * WizardItems Hook Subscriber
+ */
+class WizardItemsHookSubscriber extends \FluidTYPO3\Fluidcontent\Hooks\WizardItemsHookSubscriber implements NewContentElementWizardHookInterface {
+
+	/**
+	 * @param array $items
+	 * @param NewContentElementController $parentObject
+	 * @return void
+	 */
+	public function manipulateWizardItems(&$items, &$parentObject) {
+		parent::manipulateWizardItems($items, $parentObject);
+		unset($items['common_textpic']);
+	}
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,6 +20,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FluidTYPO3.FluidcontentCore']['types'] = array(
 );
 
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\FluidcontentCore\Provider\CoreContentProvider');
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']['fluidcontent_core'] = 'FluidTYPO3\FluidcontentCore\Hooks\WizardItemsHookSubscriber';
 
 // Prepare a global variants registration array indexed by CType value.
 // To add your own, do fx: $GLOBALS['TYPO3_CONF_VARS']['FluidTYPO3.FluidcontentCore']['variants']['textpic'][] = 'myextensionkey';


### PR DESCRIPTION
Created WizardItemsHookSubscriber to prevent the rendering of non-supported CType Textpic according to https://github.com/FluidTYPO3/fluidcontent_core/blob/development/README.md#special-note-about-the-textpic-text-with-images-content-type

Close: #135