### PR TITLE
[BUGFIX] Imagewidth and imageheight can't be edited

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -65,6 +65,5 @@ unset(
 	$GLOBALS['TCA']['tt_content']['palettes']['imageblock'],
 	$GLOBALS['TCA']['tt_content']['palettes']['imagelinks'],
 	$GLOBALS['TCA']['tt_content']['palettes']['image_accessibility'],
-	$GLOBALS['TCA']['tt_content']['palettes']['image_settings'],
 	$GLOBALS['TCA']['tt_content']['palettes']['table']
 );


### PR DESCRIPTION
The palette "image_settings" was unset.
But the fields are used here: https://github.com/FluidTYPO3/fluidcontent_core/blob/development/Resources/Private/Partials/Content/Image.html

Solution:
Configuration/TCA/Override/tt_content.php 
remove line: 
$GLOBALS['TCA']['tt_content']['palettes']['image_settings']
in the unset command.