### PR TITLE
[BUGFIX] Handle special characters in image paths correctly

### DIFF
--- a/Resources/Private/Templates/CoreContent/Image.html
+++ b/Resources/Private/Templates/CoreContent/Image.html
@@ -26,7 +26,7 @@
 <f:section name="Preview">
 	<v:resource.record.fal record="{record}" field="image" table="tt_content" as="images">
 		<f:for each="{images}" as="image" iteration="iteration">
-			<v:media.image src="{image.url}" treatIdAsReference="TRUE" alt="{image.id}" height="50" style="height: auto; max-width: 100%;" />
+			<v:media.image src="{image.uid}" treatIdAsReference="TRUE" alt="{image.id}" height="50" style="height: auto; max-width: 100%;" />
 		</f:for>
 		<f:if condition="{settings.extendedCaptions}">
 			<f:if condition="{images -> f:count()} > 0">


### PR DESCRIPTION
image.url is uriescaped, which means v:media.image will not be able to find the local file then.

Fixes #156