### PR TITLE
[BUGFIX] Fix shortcut type

### DIFF
--- a/Classes/Controller/CoreContentController.php
+++ b/Classes/Controller/CoreContentController.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\FluidcontentCore\Controller;
 use FluidTYPO3\FluidcontentCore\Provider\CoreContentProvider;
 use FluidTYPO3\Flux\Controller\AbstractFluxController;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class CoreContentController
@@ -140,6 +141,15 @@ class CoreContentController extends AbstractFluxController {
 	 */
 	public function shortcutAction() {
 
+		$record = $this->getRecord();
+		$contentUids = array_map(function($index) {
+			if (0 !== strpos($index, 'tt_content_')) {
+				return FALSE;
+			}
+			return str_replace('tt_content_', '', $index);
+		}, GeneralUtility::trimExplode(',', $record['records']));
+
+		$this->view->assign('contentUids', implode(',', $contentUids));
 	}
 
 	/**

--- a/Resources/Private/Templates/CoreContent/Shortcut.html
+++ b/Resources/Private/Templates/CoreContent/Shortcut.html
@@ -14,7 +14,7 @@
 </f:section>
 
 <f:section name="Main">
-	<v:content.render contentUids="{record.records -> v:iterator.explode()}" />
+	<v:content.render contentUids="{contentUids -> v:iterator.explode()}" />
 </f:section>
 
 </div>

--- a/Tests/Unit/Controller/CoreContentControllerTest.php
+++ b/Tests/Unit/Controller/CoreContentControllerTest.php
@@ -71,7 +71,6 @@ class CoreContentControllerTest extends BaseTestCase {
 			array('uploads'),
 			array('table'),
 			array('media'),
-			array('shortcut'),
 			array('div'),
 			array('html')
 		);
@@ -113,4 +112,32 @@ class CoreContentControllerTest extends BaseTestCase {
 		);
 	}
 
+	/**
+	 * The shortcut action should throw away all non tt_content rows that are associated
+	 * to avoid collisions and have a minimal working sample.
+	 *
+	 * @return void
+	 */
+	public function testShortcutAction() {
+
+		$instance = $this->getMock(
+			'FluidTYPO3\\FluidcontentCore\\Controller\\CoreContentController',
+			array('getRecord', 'initializeViewVariables', 'initializeViewSettings', 'initializeViewObject', 'initializeSettings')
+		);
+
+		$mockView = $this->getMock('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface');
+		$mockView->expects($this->once())->method('assign', '35,54');
+
+		$instance->expects($this->once())
+			->method('getRecord')
+			->willReturn([
+				'uid' => 1234,
+				'pid' => 456,
+				'records' => 'tt_content_45,tt_content_54,tt_blafoo_45'
+			]);
+
+		$this->inject($instance, 'view', $mockView);
+
+		$instance->shortcutAction();
+	}
 }


### PR DESCRIPTION
This fix shortcircuits the element and only passes tt_content record uids as
CSV as along as we dont have a solution for other tables yet.