### PR TITLE
[BUGFIX] Fix shortcut type

### DIFF
--- a/Classes/Controller/CoreContentController.php
+++ b/Classes/Controller/CoreContentController.php
@@ -12,6 +12,7 @@ use FluidTYPO3\FluidcontentCore\Provider\CoreContentProvider;
 use FluidTYPO3\Flux\Controller\AbstractFluxController;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * Class CoreContentController
@@ -143,13 +144,12 @@ class CoreContentController extends AbstractFluxController {
 
 		$record = $this->getRecord();
 		$contentUids = array_map(function($index) {
-			if (0 !== strpos($index, 'tt_content_')) {
+			if (0 !== strpos($index, 'tt_content_') && FALSE === MathUtility::canBeInterpretedAsInteger($index)) {
 				return FALSE;
 			}
 			return str_replace('tt_content_', '', $index);
 		}, GeneralUtility::trimExplode(',', $record['records']));
-
-		$this->view->assign('contentUids', implode(',', $contentUids));
+		$this->view->assign('contentUids', implode(',', array_filter($contentUids)));
 	}
 
 	/**

--- a/Tests/Unit/Controller/CoreContentControllerTest.php
+++ b/Tests/Unit/Controller/CoreContentControllerTest.php
@@ -126,16 +126,15 @@ class CoreContentControllerTest extends BaseTestCase {
 		);
 
 		$mockView = $this->getMock('TYPO3\\CMS\\Extbase\\Mvc\\View\\ViewInterface');
-		$mockView->expects($this->once())->method('assign', '35,54');
+		$mockView->expects($this->once())->method('assign')->with('contentUids', '45,45,54,87');
 
 		$instance->expects($this->once())
 			->method('getRecord')
 			->willReturn([
 				'uid' => 1234,
 				'pid' => 456,
-				'records' => 'tt_content_45,tt_content_54,tt_blafoo_45'
+				'records' => 'tt_content_45,45,tt_content_54,87,tt_blafoo_45'
 			]);
-
 		$this->inject($instance, 'view', $mockView);
 
 		$instance->shortcutAction();


### PR DESCRIPTION
By default, the "records" argument is saved without a prefix as the default
table is "tt_content". The previous fix will discard all records in this case.
It will also leave empty elements in contentUids for each element it filters out
because array_filter was not called on the array_map result.

Also, the test did not actually test anything because of a wrong "method()" call.