### PR TITLE
[BUGFIX] The form extension could not use with fluidcontent_core.

### DIFF
--- a/Configuration/PageTS/modWizardsMailform.ts
+++ b/Configuration/PageTS/modWizardsMailform.ts
@@ -1,0 +1,17 @@
+mod.wizards.newContentElement.wizardItems.forms {
+	elements.mailform {
+		icon = EXT:frontend/Resources/Public/Icons/ContentElementWizard/mailform.gif
+		title = LLL:EXT:cms/layout/locallang_db_new_content_el.xlf:forms_mail_title
+		description = LLL:EXT:cms/layout/locallang_db_new_content_el.xlf:forms_mail_description
+		tt_content_defValues {
+			CType = mailform
+			bodytext (
+enctype = multipart/form-data
+method = post
+prefix = tx_form
+			)
+		}
+	}
+
+	show = *
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -267,7 +267,6 @@ unset(
 	$GLOBALS['TCA']['tt_content']['types']['swfobject'],
 	$GLOBALS['TCA']['tt_content']['types']['qtobject'],
 	$GLOBALS['TCA']['tt_content']['types']['multimedia'],
-	$GLOBALS['TCA']['tt_content']['types']['mailform'],
 	$GLOBALS['TCA']['tt_content']['types']['search'],
 	$GLOBALS['TCA']['tt_content']['types']['textpic'],
 	$GLOBALS['TCA']['tt_content']['columns']['text_properties'],
@@ -294,6 +293,10 @@ unset(
 	$GLOBALS['TCA']['tt_content']['palettes']['image_accessibility'],
 	$GLOBALS['TCA']['tt_content']['palettes']['table']
 );
+
+if (FALSE === \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
+	unset( $GLOBALS['TCA']['tt_content']['types']['mailform'] );
+}
 
 foreach ($GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'] as $index => $item) {
 	if ($item[1] === 'textpic') {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -54,4 +54,9 @@ unset($types, $i);
 // Include new content elements to modWizards
 if (TRUE === version_compare(TYPO3_version, '7.3', '>')) {
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:fluidcontent_core/Configuration/PageTS/modWizards.ts">');
+
+	// If the form extension is loaded, then include the mailform element to modWizards
+	if (TRUE === \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
+		\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:fluidcontent_core/Configuration/PageTS/modWizardsMailform.ts">');
+	}
 }


### PR DESCRIPTION
Now it is checked whether the form extension has been loaded,
in order to prevent the deletion of the TCA configuration.
Also the modWizards configuration is added when the TYPO3 Version is greater than 7.3.
Only tested in TYPO3 7.4.