### PR TITLE
dont print the header if header type is 0

### DIFF
--- a/Resources/Private/Partials/Content/Header.html
+++ b/Resources/Private/Partials/Content/Header.html
@@ -1,6 +1,8 @@
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 
-<v:tag name="h{settings.content.settings.header.type -> v:or(alternative: record.header_layout) -> v:or(alternative: settings.header.type)}"
-         class="{settings.content.settings.header.className}" hideIfEmpty="{settings.content.settings.header.hideIfEmpty -> v:or(alternative: 1)}">
-	{record.header -> f:format.raw()}
-</v:tag>
+<f:if condition="{settings.content.settings.header.type}">
+	<v:tag name="h{settings.content.settings.header.type -> v:or(alternative: record.header_layout) -> v:or(alternative: settings.header.type)}"
+		 class="{settings.content.settings.header.className}" hideIfEmpty="{settings.content.settings.header.hideIfEmpty -> v:or(alternative: 1)}">
+		{record.header -> f:format.raw()}
+	</v:tag>
+</f:if>


### PR DESCRIPTION
Dont print the header if settings.content.settings.header.type is 0 
You could have something like plugin.tx_fluidcontentcore.settings.header.types = 0,2,3,4,5,6 so your content could have a header that there isnt displayed in FE. 
An element without header shows Edit Page Content "una prueba bla blas bla ....." on page "AFI - Inversión para competitividad pymes" and it could be very long or for preview reasons