### PR TITLE
fix in section index

### DIFF
--- a/Resources/Private/Partials/Content/SectionIndex.html
+++ b/Resources/Private/Partials/Content/SectionIndex.html
@@ -1,8 +1,6 @@
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 <f:for each="{v:content.get(sectionIndexOnly: 1, pageUid: menuPage)}" as="contentElementRecord">
-	<f:link.page pageUid="{menuPage}" section="{contentElementRecord.header
-							-> v:or(alternative: contentElementRecord.titleAttribute)
-							-> v:or(alternative: 'content-{record.uid}') -> v:format.url.sanitizeString()}">
+	<f:link.page pageUid="{menuPage}" section="c{record.uid}">
 		{contentElementRecord.header -> v:or(alternative: contentElementRecord.titleAttribute)
 		-> v:or(alternative: '{contentElementRecord.bodyText -> f:format.html()}')
 		-> f:format.crop(maxCharacters: content.settings.preview.maxCharacters)}

--- a/Resources/Private/Partials/Content/SectionIndex.html
+++ b/Resources/Private/Partials/Content/SectionIndex.html
@@ -1,6 +1,6 @@
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 <f:for each="{v:content.get(sectionIndexOnly: 1, pageUid: menuPage)}" as="contentElementRecord">
-	<f:link.page pageUid="{menuPage}" section="c{record.uid}">
+	<f:link.page pageUid="{menuPage}" section="c{contentElementRecord.uid}">
 		{contentElementRecord.header -> v:or(alternative: contentElementRecord.titleAttribute)
 		-> v:or(alternative: '{contentElementRecord.bodyText -> f:format.html()}')
 		-> f:format.crop(maxCharacters: content.settings.preview.maxCharacters)}


### PR DESCRIPTION
If anchors have an id (/Users/fernando/tmp/vagrant-t3a/data/web/typo3conf/ext/t3atheme/Resources/Private/Extension/FluidcontentCore/Layouts/Default.html, NoHeader.html) then the section section index should be referenced in the same way