### PR TITLE
[BUGFIX] Populate variants and versions dropdown for new records

### DIFF
--- a/Classes/UserFunction/ProviderField.php
+++ b/Classes/UserFunction/ProviderField.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\FluidcontentCore\UserFunction;
 use FluidTYPO3\FluidcontentCore\Provider\CoreContentProvider;
 use FluidTYPO3\FluidcontentCore\Service\ConfigurationService;
 use TYPO3\CMS\Core\Resource\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
@@ -64,8 +65,12 @@ class ProviderField {
 	 * @return string
 	 */
 	public function createVariantsField(array $parameters) {
-		$parameters['row'] = $this->loadRecord('tt_content', $parameters['row']['uid']);
-		$extensionKeys = $this->configurationService->getVariantExtensionKeysForContentType($parameters['row']['CType']);
+		ArrayUtility::mergeRecursiveWithOverrule($parameters['row'], $this->loadRecord('tt_content', $parameters['row']['uid']));
+		// $parameters['row'] = $this->loadRecord('tt_content', $parameters['row']['uid']);
+
+		$cType = is_array($parameters['row']['CType']) ? current($parameters['row']['CType']) : $parameters['row']['CType'];
+
+		$extensionKeys = $this->configurationService->getVariantExtensionKeysForContentType($cType);
 		$defaults = $this->configurationService->getDefaults();
 		$preSelected = $parameters['row']['content_variant'];
 		if (CoreContentProvider::MODE_PRESELECT === $defaults['mode'] && TRUE === empty($preSelected)) {
@@ -138,7 +143,11 @@ class ProviderField {
 	 * @return string
 	 */
 	public function createVersionsField(array $parameters) {
-		$parameters['row'] = $this->loadRecord('tt_content', $parameters['row']['uid']);
+		ArrayUtility::mergeRecursiveWithOverrule($parameters['row'], $this->loadRecord('tt_content', $parameters['row']['uid']));
+		// $parameters['row'] = $this->loadRecord('tt_content', $parameters['row']['uid']);
+
+		$cType = is_array($parameters['row']['CType']) ? current($parameters['row']['CType']) : $parameters['row']['CType'];
+
 		$options = array();
 		$defaults = $this->configurationService->getDefaults();
 		$preSelectedVariant = $parameters['row']['content_variant'];
@@ -152,10 +161,10 @@ class ProviderField {
 			}
 		}
 
-		$versions = $this->configurationService->getVariantVersions($parameters['row']['CType'], $preSelectedVariant);
+		$versions = $this->configurationService->getVariantVersions($cType, $preSelectedVariant);
 		if (TRUE === is_array($versions) && 0 < count($versions)) {
 			foreach ($versions as $version) {
-				$icon = $this->configurationService->getIconFromVersion($preSelectedVariant, $parameters['row']['CType'], $version);
+				$icon = $this->configurationService->getIconFromVersion($preSelectedVariant, $cType, $version);
 				$versionIcon = '<img src="' . $icon . '" alt="" /> ';
 				$options[$version] = array($versionIcon, $version);
 			}


### PR DESCRIPTION
When creating a new record the dropdowns for variants and versions are empty until i hit the save button. This happens because the userFuncs providing the dropdowns start by loading the record/row, which – for obvious reasons – returns nothing in this case.

Therefor I'm using the row already given by the parameter `$parameters`.
The only difference I saw were, that a few items such as cType are in turn an array instead of a plain string. So I had to work around this by grabbing the cType from that array.

I don't really know, why the record is loaded from the database anyway as `$parameters` should already supply everything.